### PR TITLE
feat: unified work lifecycle — work-start, work-end, work-pause, work-resume (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,7 +534,11 @@ Full design: `docs/superpowers/specs/2026-04-09-workspace-model-design.md`
 - `workspace-init` — one-time setup; creates `~/claude/private/<project>/` or
   `~/claude/public/<project>/` with routing CLAUDE.md, gitignored project symlink
   via `.git/info/exclude`, and all subdirectories
-- `epic` — full epic lifecycle; detects current state and routes to start or close workflow; start creates branches, scaffolds `design/JOURNAL.md` with SHA baseline, links or creates GitHub issue, optionally invokes brainstorming; close routes artifacts per `## Routing` config, merges `design/JOURNAL.md` into project `DESIGN.md`, posts specs to GitHub issue, handles branch cleanup
+- `work-start` — unified entry point for all work; detects branch state (6 states including paused, orphaned, misaligned); creates `issue-NNN-<slug>` branches in both repos atomically; scaffolds `.meta` + `JOURNAL.md` with SHA baseline and design routing; runs platform coherence, protocols, IntelliJ pre-checks; replaces the former "work-start + /epic begin" two-step
+- `work-end` — closes the current branch; promotes artifacts per routing config; merges `design/JOURNAL.md` into DESIGN.md with three-way diff preview; posts specs to GitHub issue; closes issue; marks branch with `design/EPIC-CLOSED.md`; returns both repos to main. Replaces "epic close"
+- `work-pause` — saves current context; stashes uncommitted changes with recorded references; writes `.paused` marker to workspace main atomically (push must succeed before switching repos); switches both repos to main
+- `work-resume` — reads `.paused`; switches both repos back to branch; removes pause marker from main; restores stashed changes using recorded references (not bare stash pop); runs pre-checks
+- `epic` — **deprecated**. Use `work-start` (replaces `/epic begin`) and `work-end` (replaces `/epic close`). Retained for reference during migration
 
 **Generic foundation skills** (not invoked directly, referenced via Prerequisites):
 - `code-review-principles` — universal code review checklist (extended by `java-code-review`)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,6 +72,33 @@ Use `forage` for session-time capture and `harvest` for deduplication. The `gard
 
 ---
 
+## Work Lifecycle
+
+Four commands replace the fragmented `work-start` + `epic begin/close` workflow.
+Unified entry point detects branch state and handles the full session lifecycle.
+
+**Key decisions:**
+
+| Decision | Chosen | Why | Alternatives Rejected |
+|---|---|---|---|
+| Branch naming | `issue-NNN-<slug>` for all branches | Issue number is the stable key; slug is a convenience | `epic-<name>` prefix (forces artificial epic vs issue distinction; breaks java-update-design detection) |
+| `.meta` present on all branches | Every branch gets `.meta` + `JOURNAL.md` | No lightweight vs epic distinction — consistent behaviour regardless of scope | Separate lightweight/epic branch types (maintenance complexity, detection ambiguity) |
+| `design-repo` stored in `.meta` | `design-repo: workspace|project` persisted at branch creation | Routing config may change between sessions; `.meta` is the stable source of truth at close | Re-derive from routing config at `work-end` (stale routing config causes wrong merge target) |
+| Detection state ordering | Orphaned `.meta` check (state 3) before misaligned branches (state 4) | Orphaned state also satisfies "misaligned" — wrong order causes Branch Switch Helper to switch to a deleted branch | Checking misalignment first (breaks for branches deleted after PR merge) |
+| Atomic pause | `work-pause` Step 3 push must succeed before Step 4 writes `.paused` to main | `.paused` on main must always correspond to committed pause record in `.meta` on the branch | Write `.paused` optimistically (leaves orphaned `.paused` if push fails) |
+| Stash references recorded | Record `stash@{N}` at pause; `work-resume` pops by reference not by position | Bare `stash pop` pops wrong stash if user manually stashes between pause and resume | Bare `stash pop` (works only if no manual stash operations occurred) |
+| Journal merge branch context | When `design → workspace`, journal merge happens during `work-end` 8a main-visit, not after returning to epic branch | Epic branch is discarded at close — commits to it after 8a are lost | Merge on epic branch, cherry-pick to main (complex; 8a already does the workspace cherry-pick) |
+| `EPIC-CLOSED.md` location | `$WORKSPACE/design/EPIC-CLOSED.md` on the workspace epic branch | Consistent with all other lifecycle files (`.meta`, `JOURNAL.md`); hygiene scan already traverses epic branches for `.meta` detection | Workspace root (inconsistent location; no advantage over design/) |
+| Epic deprecation | `epic/SKILL.md` retained with deprecation header; not deleted | Migration period — existing sessions still invoke it | Hard delete (breaks in-flight sessions) |
+
+**java-update-design workspace mode detection (corrected):**
+
+Previously checked `epic-*` branch prefix, silently bypassing journal on `issue-NNN-*` branches.
+Now checks `.meta` + `JOURNAL.md` + not-on-main using `$WORKSPACE` path (not CWD).
+Branch name prefix must never be part of workspace mode detection.
+
+---
+
 ## Design Backlog
 
 No open design decisions at this time.

--- a/docs/prompt-snippets.md
+++ b/docs/prompt-snippets.md
@@ -31,6 +31,28 @@ Replace `[java-dev|python-dev|ts-dev]` with the appropriate dev skill for the pr
 
 ---
 
+## Content creation workflow
+
+Paste at the start of any session involving writing articles, notes, essays, briefs, or news:
+
+```
+write-content for all content. Load personal style file if available (~/claude-workspace/writing-styles/mark-proctor-voice.md). Any gaps, deferred ideas, or out-of-scope topics identified during writing must be captured as GitHub issues or idea-log entries before the session ends — not just noted in the draft.
+
+[describe what you want to write, or provide the topic/subject]
+```
+
+---
+
+## Content workflow — what each instruction does
+
+| Instruction | What it enforces |
+|-------------|-----------------|
+| `write-content` | Content type selection (Note/Article/Brief/News + subtype), structure principles, anti-slop guidance, form-specific writing rules |
+| Personal style file | Linguistic fingerprint — how the author sounds at sentence level; load alongside write-content |
+| Capture gaps as issues | Any deferred concern or out-of-scope topic identified during writing → GitHub issue or idea-log before session ends |
+
+---
+
 ## Notes
 
 - `~/.claude/prompt-snippets.md` previously held a general snippet; that content is now superseded by `work-start` and `ide-tooling` — this file is the canonical replacement

--- a/docs/skills-catalog.md
+++ b/docs/skills-catalog.md
@@ -80,22 +80,35 @@ One-time workspace setup per project per machine:
 
 **Triggers:** "init workspace", "set up workspace", "create workspace for <project>", `/workspace-init`.
 
-#### **epic**
-Single entry point for the full epic lifecycle — detects current state and routes automatically:
-- No active epic → offers to create branches, scaffold `design/JOURNAL.md` with SHA baseline, link or create a GitHub issue, optionally invoke brainstorming
-- Active epic → asks whether to close it or begin a new one
+#### **work-start** *(replaces epic begin + former work-start)*
+Unified entry point for all work. Detects current branch state (6 states including paused, orphaned, misaligned) and routes accordingly. On the new-branch path: creates `issue-NNN-<slug>` branches in both repos atomically, scaffolds `design/.meta` + `JOURNAL.md` with SHA baseline and design routing, runs platform coherence / protocols / IntelliJ pre-checks, offers brainstorming.
 
-**Starting an epic:** creates matching branches in the project repo and workspace, scaffolds `design/.meta` with epic name and SHA baseline, links to an existing GitHub issue or creates one.
+**Triggers:** "work-start", start of any work session, first instruction in a work-item prompt.
 
-**Closing an epic:** routes artifacts per `## Routing` config in workspace CLAUDE.md, merges `design/JOURNAL.md` into the project `DESIGN.md`, posts specs to the GitHub issue, handles branch cleanup with approve-all or step-by-step confirmation.
+#### **work-end** *(replaces epic close)*
+Closes the current branch. Promotes artifacts per routing config (three-layer cascade), merges `design/JOURNAL.md` into project `DESIGN.md` with three-way diff preview, posts specs to GitHub issue, closes issue, marks branch with `design/EPIC-CLOSED.md`, returns both repos to main.
 
-**Artifact routing** — three-layer config controls where artifacts go at epic close:
+**Artifact routing** — three-layer config controls where artifacts go:
 - Layer 1 (built-in): all artifacts → project repo
 - Layer 2 (global): `~/.claude/CLAUDE.md ## Routing` — default destination
 - Layer 3 (workspace): `## Routing` table in workspace CLAUDE.md — per-artifact override
-Valid destinations: `project`, `workspace` (workspace/main), `alternative <path>`
 
-**Triggers:** "begin epic", "new epic", "close epic", "finish epic", `/epic`.
+**Triggers:** "work-end", "close this branch", "wrap up this issue".
+
+#### **work-pause**
+Saves current context, stashes uncommitted changes with recorded references (`stash@{N}`), atomically writes `.paused` marker to workspace main (push must succeed before switching repos), switches both repos to main. Only one paused branch at a time.
+
+**Triggers:** "work-pause", "pause this work", "switch to something else".
+
+#### **work-resume**
+Resumes a paused branch. Reads `.paused` from workspace main, switches both repos back to the branch using exact branch-name matching, removes pause marker, restores stashed changes using recorded references, runs pre-checks.
+
+**Triggers:** "work-resume", "resume", "go back to that branch".
+
+#### **epic** *(deprecated — use work-start / work-end)*
+Retained for reference during migration. Use `work-start` instead of `/epic begin` and `work-end` instead of `/epic close`.
+
+**Triggers:** "begin epic", "new epic", "close epic", "finish epic", `/epic` (deprecated).
 
 #### **install-skills**
 One-time bootstrap wizard for new environments:

--- a/epic/SKILL.md
+++ b/epic/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: epic
 description: >
-  Use when a development epic needs to begin or wrap up — user says "begin
-  epic", "new epic", "close epic", "finish epic", or invokes /epic. Detects
-  whether an epic is currently active and routes accordingly.
+  DEPRECATED. Use work-start (replaces /epic begin) and work-end (replaces
+  /epic close). work-pause and work-resume are new. The workflows below are
+  preserved for reference during migration only.
 ---
 
-# Epic
+> ⚠️ **This skill is deprecated.** Use instead:
+> - `work-start` — replaces `/epic begin` (branch creation is now integrated)
+> - `work-end`   — replaces `/epic close`
+> - `work-pause` — new: save context, switch to main
+> - `work-resume` — new: restore context, return to branch
+>
+> The workflows below are preserved for reference during migration.
+> Retire this skill once all sessions use the new commands.
+
+# Epic (deprecated — see above)
 
 Single entry point for the full epic lifecycle. Detects whether an epic is
 currently active and routes to the appropriate workflow — start or close.

--- a/epic/SKILL.md
+++ b/epic/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: epic
 description: >
-  DEPRECATED. Use work-start (replaces /epic begin) and work-end (replaces
-  /epic close). work-pause and work-resume are new. The workflows below are
-  preserved for reference during migration only.
+  Use when a development epic needs to begin or wrap up — user says "begin
+  epic", "new epic", "close epic", "finish epic", or invokes /epic. DEPRECATED:
+  replaced by the work lifecycle skills. Workflows preserved for migration.
 ---
 
 > ⚠️ **This skill is deprecated.** Use instead:

--- a/handover/SKILL.md
+++ b/handover/SKILL.md
@@ -2,12 +2,10 @@
 name: handover
 description: >
   Use when ending a session and wanting to preserve context for resumption,
-  OR when starting a session and needing to resume from where things left off —
-  says "create a handover", "end of session", "update the handover",
-  "write a handover", or "resume handover". When creating: generates a concise
-  HANDOFF.md with lazy references to deeper context. When resuming: locates and
-  reads HANDOFF.md from the correct location (workspace or project repo).
-  NOT for design records (use design-snapshot) or project narrative (use write-blog).
+  OR when a session is beginning and needing to resume from where things left
+  off — says "create a handover", "end of session", "update the handover",
+  "write a handover", or "resume handover". NOT for design records (use
+  design-snapshot) or project narrative (use write-blog).
 ---
 
 # Session Handover

--- a/ide-tooling/SKILL.md
+++ b/ide-tooling/SKILL.md
@@ -3,9 +3,9 @@ name: ide-tooling
 description: >
   Use when any IDE operation is needed — renaming a symbol, moving a file,
   finding all references, navigating to a definition, exploring a type hierarchy,
-  checking call chains, getting diagnostics, or any other operation where
-  IntelliJ provides semantic correctness that bash/grep cannot. Also use when
-  the user asks which tool to use for a code navigation or refactoring task.
+  diagnosing dependency chains, or any other operation where IntelliJ provides
+  semantic correctness that bash/grep cannot. Also use when the user asks
+  which tool to use for a code navigation or refactoring task.
 ---
 
 # IDE Tooling — IntelliJ MCP Guide

--- a/implementation-doc-sync/SKILL.md
+++ b/implementation-doc-sync/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: implementation-doc-sync
 description: >
-  Use after implementing a feature or fix to sync documentation scoped to what
-  changed this session — user says "sync docs", "update docs", "doc sweep", or
-  invoked from a prompt snippet at end of session. Checks only docs relevant to
-  the changed components, not the whole project. NOT a full project health check
-  (use project-health for that). NOT a design journal update (java-git-commit
-  handles that). Covers drift, broken cross-references, staleness, and gaps in
-  the specific areas touched.
+  Use when documentation needs syncing — user says "sync docs", "update docs",
+  "doc sweep", or invoked from a prompt snippet at session end. Scoped to what
+  changed this session only, not a full project sweep. NOT a design journal
+  update (java-git-commit handles that).
 ---
 
 # Implementation Doc Sync

--- a/java-update-design/SKILL.md
+++ b/java-update-design/SKILL.md
@@ -45,10 +45,10 @@ This skill is invoked by `java-git-commit` when:
 - **Only operates in type: java repositories** — other project types use different documentation patterns
 - DESIGN.md lives at `design/DESIGN.md` in the workspace (CWD). In the workspace
   model, the project is accessed via `add-dir`.
-- **Epic close:** When the epic completes, `epic` reads `design/JOURNAL.md`,
+- **Branch close:** When the branch completes, `work-end` reads `design/JOURNAL.md`,
   generates a three-way merge preview (base + current project + journal), and
   applies the changes to the project `DESIGN.md` with user confirmation.
-  The journal itself is posted to the GitHub epic issue, then discarded.
+  The journal entry is posted to the GitHub issue, then the branch is cleaned up.
 - **Never apply changes without explicit user confirmation** (a plain "YES" or
   equivalent). If in doubt, ask.
 - Focus only on **architectural impact**: new/removed components, changed
@@ -65,26 +65,38 @@ This skill is invoked by `java-git-commit` when:
 All three conditions must be true for workspace mode. Check in order:
 
 ```bash
-# 1. Are we on an epic branch?
-git branch --show-current   # must match epic-* pattern
+# 1. Does design/.meta exist?
+ls "$WORKSPACE/design/.meta" 2>/dev/null
 
-# 2. Does .meta exist?
-ls design/.meta 2>/dev/null
+# 2. Does design/JOURNAL.md exist?
+ls "$WORKSPACE/design/JOURNAL.md" 2>/dev/null
 
-# 3. Does JOURNAL.md exist?
-ls design/JOURNAL.md 2>/dev/null
+# 3. Is the workspace NOT on main?
+[ "$(git -C "$WORKSPACE" branch --show-current)" != "main" ]
 ```
 
-- All three present → **workspace mode**: proceed with journal entry workflow below.
-- Any absent → **direct mode**: fall back to updating project `DESIGN.md` directly.
-  Do not prompt; do not create JOURNAL.md. `epic` is responsible for creating it.
+Where `$WORKSPACE` is resolved from CLAUDE.md:
+```bash
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+```
 
-**Why all three?** JOURNAL.md presence alone is unreliable — a stale JOURNAL.md from a previous epic that was not cleaned up would silently activate workspace mode when it should not. Branch + `.meta` + JOURNAL.md together confirm an active epic.
+- All three true → **workspace mode**: proceed with journal entry workflow below.
+- Any false → **direct mode**: fall back to updating project `DESIGN.md` directly.
+  Do not prompt; do not create JOURNAL.md. `work-start` is responsible for creating it.
 
-In workspace mode: read `design/JOURNAL.md` to understand which sections have
-already been journalled during this epic before adding or updating an entry.
+**Why these three and not branch prefix?** `.meta` + `JOURNAL.md` + not-on-main
+together confirm an active working branch regardless of naming convention. The
+`epic-*` prefix check broke for `issue-NNN-*` branches — this fix handles all
+branch names uniformly.
 
-> **Workspace mode path:** If `design/JOURNAL.md` was found in Step 1, skip Steps 5 and 6. Proceed directly to Step 7 after completing Steps 2-4 (read DESIGN.md for section names, review changes, map to sections). The journal entry (Step 7) is the only write action in workspace mode.
+**Why not branch prefix?** Branch name prefix (`epic-*`) is fragile — it breaks
+silently for `issue-NNN-*` branches, causing every commit to write directly to
+`DESIGN.md` with no error, bypassing the journal entirely.
+
+In workspace mode: read `$WORKSPACE/design/JOURNAL.md` to understand which sections
+have already been journalled during this branch before adding or updating an entry.
+
+> **Workspace mode path:** If workspace mode is detected in Step 1, skip Steps 5 and 6. Proceed directly to Step 7 after completing Steps 2-4 (read DESIGN.md for section names, review changes, map to sections). The journal entry (Step 7) is the only write action in workspace mode.
 
 ### Step 1a: Check for modular structure
 

--- a/java-update-design/SKILL.md
+++ b/java-update-design/SKILL.md
@@ -84,14 +84,10 @@ WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*
 - Any false → **direct mode**: fall back to updating project `DESIGN.md` directly.
   Do not prompt; do not create JOURNAL.md. `work-start` is responsible for creating it.
 
-**Why these three and not branch prefix?** `.meta` + `JOURNAL.md` + not-on-main
-together confirm an active working branch regardless of naming convention. The
-`epic-*` prefix check broke for `issue-NNN-*` branches — this fix handles all
-branch names uniformly.
-
-**Why not branch prefix?** Branch name prefix (`epic-*`) is fragile — it breaks
-silently for `issue-NNN-*` branches, causing every commit to write directly to
-`DESIGN.md` with no error, bypassing the journal entirely.
+**Why these three and not branch prefix?** Branch name prefix (`epic-*`) breaks
+silently for `issue-NNN-*` branches — every commit writes directly to `DESIGN.md`
+with no error, bypassing the journal entirely. `.meta` + `JOURNAL.md` + not-on-main
+confirms an active working branch regardless of naming convention.
 
 In workspace mode: read `$WORKSPACE/design/JOURNAL.md` to understand which sections
 have already been journalled during this branch before adding or updating an entry.

--- a/java-update-design/SKILL.md
+++ b/java-update-design/SKILL.md
@@ -224,7 +224,7 @@ Focus on reasoning and context — not implementation details. 2-6 sentences.]
 
 **Rules:**
 - Use the exact section name from the project `DESIGN.md` in the `§` anchor
-  (e.g. `§Architecture`, `§Data Model`) — this is the merge map at epic close
+  (e.g. `§Architecture`, `§Data Model`) — this is the merge map at branch close (work-end)
 - If an entry for this `§Section` already exists in `JOURNAL.md` → update it
   in place (the journal is a living document; git history preserves the evolution)
 - If this is a new section affected → append a new entry at the end
@@ -249,13 +249,13 @@ After writing the entry, verify it has a `§SectionName` anchor in the header be
 grep -c "^### .*·.*§" design/JOURNAL.md
 ```
 
-If the entry you just wrote does not contain `· §SectionName` in its header — **do not commit**. The entry will be silently skipped at epic close, permanently losing the design context. Fix the header first:
+If the entry you just wrote does not contain `· §SectionName` in its header — **do not commit**. The entry will be silently skipped at branch close (work-end), permanently losing the design context. Fix the header first:
 
 ```markdown
 ### YYYY-MM-DD · §SectionName        ← §SectionName is required; without it the merge is a no-op
 ```
 
-This is not optional. An anchor-free journal entry is invisible to the epic close merge.
+This is not optional. An anchor-free journal entry is invisible to the work-end merge.
 
 ---
 
@@ -274,7 +274,7 @@ Avoid these mistakes when updating DESIGN.md:
 | Skipping "Reason:" in proposals | User doesn't understand why change needed | Always explain rationale |
 | Not reading existing DESIGN.md first | Proposals conflict with structure | Always read full file before proposing |
 | Mentioning AI/tools in DESIGN.md | Breaks professional documentation standards | Never mention Claude, AI, or tooling in the doc itself |
-| Writing to design/DESIGN.md directly | Bypasses the journal; merge at epic close loses context | Always write to design/JOURNAL.md with §Section anchors |
+| Writing to design/DESIGN.md directly | Bypasses the journal; merge at branch close (work-end) loses context | Always write to design/JOURNAL.md with §Section anchors |
 
 ## Document Structure Check
 

--- a/update-primary-doc/SKILL.md
+++ b/update-primary-doc/SKILL.md
@@ -53,7 +53,7 @@ Before doing anything else, check whether this session is running inside a works
 ls design/JOURNAL.md 2>/dev/null && echo "workspace-mode" || echo "direct-mode"
 ```
 
-- **Workspace mode** (file found): Do not sync to the primary doc directly. Instead, write a journal entry to `design/JOURNAL.md` using the entry format below. The primary doc is updated at epic close via `epic`. Skip Steps 1–7.
+- **Workspace mode** (file found): Do not sync to the primary doc directly. Instead, write a journal entry to `design/JOURNAL.md` using the entry format below. The primary doc is updated at branch close via `work-end`. Skip Steps 1–7.
 - **Direct mode** (file not found): Proceed with the existing Sync Rules workflow unchanged (Steps 1–7 below). No file is created; detection is silent.
 
 **In workspace mode — journal entry format:**

--- a/work-end/SKILL.md
+++ b/work-end/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: work-end
 description: >
-  Close the current working branch. Promotes artifacts per routing config,
-  merges the design journal into DESIGN.md, closes the GitHub issue, and
-  returns both repos to main. Replaces "epic close". Must be invoked from
-  the working branch (not main).
+  Use when the current branch is complete and ready to close — user says
+  "work-end", "close this branch", or "wrap up this issue". Must be invoked
+  from the working branch, not main. Replaces "epic close".
 ---
 
 # work-end

--- a/work-end/SKILL.md
+++ b/work-end/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: work-end
+description: >
+  Close the current working branch. Promotes artifacts per routing config,
+  merges the design journal into DESIGN.md, closes the GitHub issue, and
+  returns both repos to main. Replaces "epic close". Must be invoked from
+  the working branch (not main).
+---
+
+# work-end
+
+Closes the current branch cleanly. Promotes artifacts, merges the journal,
+closes the issue, marks the branch closed, returns to main.
+
+---
+
+## Path Resolution (run first, always)
+
+```bash
+PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+```
+
+---
+
+## Pre-conditions
+
+Check in order before proceeding:
+
+1. **If `$WORKSPACE/design/.paused` exists** → hard stop.
+   "You have a paused branch. Invoke `work-resume` first, then `work-end`."
+
+2. **`$WORKSPACE/design/.meta` must exist on the current branch** → proceed.
+
+3. **If `$WORKSPACE/design/.meta` exists but `$CURRENT_WORKSPACE == main`** (orphaned)
+   → hard stop. Offer to switch to the surviving branch and close from there, or discard.
+
+---
+
+## Step 0 — Resolve paths
+
+```bash
+PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+OWNER_REPO=$(grep "GitHub repo:" CLAUDE.md | head -1 | sed 's/.*GitHub repo: *//')
+```
+
+---
+
+## Step 1 — Read context and extract variables
+
+```bash
+cat "$WORKSPACE/design/.meta"
+
+BRANCH_NAME=$(grep "^branch:" "$WORKSPACE/design/.meta" | sed 's/branch: //')
+PROJECT_SHA=$(grep "^project-sha:" "$WORKSPACE/design/.meta" | sed 's/project-sha: //')
+ISSUE_N=$(grep "^issue:" "$WORKSPACE/design/.meta" | sed 's/issue: //')
+```
+
+`$BRANCH_NAME`, `$PROJECT_SHA`, and `$ISSUE_N` are used throughout Steps 3–10.
+Extract once here — never re-read from `.meta` in later steps.
+
+---
+
+## Step 2 — Flyway V re-scan
+
+Re-scan at close time — another branch may have claimed the same V numbers since
+branch creation.
+
+```bash
+git -C "$PROJECT" fetch --all 2>/dev/null || echo "⚠️ No network — scan skipped"
+```
+
+If conflict detected: offer `[R]` renumber affected migration files, `[A]` abort.
+Block close until resolved.
+
+---
+
+## Step 3 — Resolve routing and set DESIGN_REPO
+
+Read three-layer routing cascade for each artifact type. Warn on deprecated
+vocabulary (`base`, `project repo`, `design-journal`). Show resolved table;
+user confirms before proceeding.
+
+**Capability detection** — for each resolved destination:
+```bash
+detect_capability() {
+  local dest="$1"
+  if [ -d "$dest/.git" ]; then
+    git -C "$dest" remote get-url origin &>/dev/null 2>&1 \
+      && echo "remote-git" || echo "local-git"
+  else
+    echo "filesystem"
+  fi
+}
+```
+
+**Specs routing is non-configurable** — specs always route to `project`
+(`$PROJECT/docs/specs/`). If the cascade resolves `specs → workspace`, override
+with a warning: "Specs routing overridden to project — not user-configurable."
+
+**`$DESIGN_REPO` — read from `.meta`, do NOT re-derive from routing config:**
+```bash
+DESIGN_REPO_KEY=$(grep "^design-repo:" "$WORKSPACE/design/.meta" | sed 's/design-repo: //')
+[ "$DESIGN_REPO_KEY" = "workspace" ] && DESIGN_REPO="$WORKSPACE" || DESIGN_REPO="$PROJECT"
+```
+
+`$DESIGN_REPO` must remain available through Step 8d. Do not recalculate it in
+subsequent steps.
+
+---
+
+## Step 4 — Inventory artifacts
+
+```bash
+ls "$WORKSPACE/adr/" 2>/dev/null | grep -v INDEX.md
+ls "$WORKSPACE/blog/" 2>/dev/null | grep -v INDEX.md
+ls "$WORKSPACE/snapshots/" 2>/dev/null | grep -v INDEX.md
+ls "$WORKSPACE/specs/$BRANCH_NAME/" 2>/dev/null
+ls "$WORKSPACE/plans/" 2>/dev/null | grep -v "^attic$"
+cat "$WORKSPACE/design/JOURNAL.md"
+```
+
+---
+
+## Step 5 — Journal validation
+
+**5a — DESIGN.md existence**
+If `$DESIGN_REPO/DESIGN.md` is missing:
+- `[C]` Create from journal entries — journal becomes the initial DESIGN.md content
+- `[S]` Skip merge entirely
+
+**5b — Section heading drift**
+Re-hash H2 headings in `$DESIGN_REPO/DESIGN.md`. Compare against `design-section-hashes`
+in `.meta`. For each `§Section` anchor in JOURNAL.md, verify its heading still exists
+unchanged in DESIGN.md.
+```bash
+STORED=$(grep "^design-section-hashes:" "$WORKSPACE/design/.meta" | sed 's/design-section-hashes: //')
+CURRENT=$(grep "^## " "$DESIGN_REPO/DESIGN.md" 2>/dev/null \
+  | while read h; do printf "%s:%s|" "$(printf '%s' "$h" | shasum -a 256 | cut -c1-8)" "$h"; done)
+```
+If drift: `[U]` update journal anchors, `[S]` skip drifted sections, `[A]` abort.
+
+**5c — Anchor validation**
+Count `^### .*·.*§` lines vs total `^### ` lines in JOURNAL.md.
+If any entries lack anchors: `[F]` fix via java-update-design, `[S]` skip merge,
+`[C]` continue accepting loss.
+
+**5d — Empty journal**
+If no entries at all:
+- `[W]` Write retrospective via java-update-design
+- `[S]` Skip and accept permanent loss
+
+---
+
+## Step 6 — Select specs for GitHub posting
+
+If tracking enabled: list `$WORKSPACE/specs/$BRANCH_NAME/`, ask which to post as
+collapsible comments on the GitHub issue. Skip silently if tracking disabled.
+
+---
+
+## Step 7 — Present close plan
+
+```
+work-end close plan — <branch-name>
+
+  Flyway V check     ✅ no conflicts
+  Artifact routing
+  ├── adr/<N>        → project      [remote-git]
+  ├── blog/<N>       → workspace    [remote-git]
+  ├── specs/<N>      → project      [remote-git]
+  └── snapshots/<N>  → workspace    [remote-git]
+  Plan archiving     → plans/attic/<branch-name>/  [workspace main]
+  Journal merge      → DESIGN.md  (<N> sections)
+  Spec posting       → #<N>  (<filenames>)
+  Issue              → close #<N>
+  Publish blog       → offer after (N entries staged)
+
+Approve all, or step by step? (all / step)
+```
+
+---
+
+## Step 8 — Execute
+
+Failures are reported but do not stop remaining steps, **except**: journal merge
+failure prompts the user before continuing to issue close.
+
+### 8a — Batch workspace-main operations (single main-visit)
+
+```bash
+# Stash any uncommitted workspace changes
+git -C "$WORKSPACE" status --short | grep -q . && git -C "$WORKSPACE" stash
+
+git -C "$WORKSPACE" checkout main
+git -C "$WORKSPACE" pull --rebase origin main
+
+# Promote workspace-routed artifacts (blog, snapshots, etc.)
+# For each artifact file in the Step 4 inventory where routing destination = workspace:
+for each workspace-routed artifact:
+  mkdir -p "$WORKSPACE/<dest>/"
+  git -C "$WORKSPACE" checkout "$BRANCH_NAME" -- <artifact-files>
+  git -C "$WORKSPACE" add "<dest>/"
+  git -C "$WORKSPACE" commit -m "feat: promote <type> from $BRANCH_NAME"
+
+# Archive plans to attic
+if plans exist:
+  git -C "$WORKSPACE" checkout "$BRANCH_NAME" -- plans/<files>
+  mkdir -p "$WORKSPACE/plans/attic/$BRANCH_NAME"
+  mv "$WORKSPACE/plans/<files>" "$WORKSPACE/plans/attic/$BRANCH_NAME/"
+  git -C "$WORKSPACE" add -A
+  git -C "$WORKSPACE" commit -m "archive($BRANCH_NAME): move plans to attic"
+
+# If DESIGN_REPO = workspace: perform journal merge here while on workspace main
+# (see 8d note — merge must happen on main, not on epic branch)
+if [ "$DESIGN_REPO_KEY" = "workspace" ]:
+  git -C "$WORKSPACE" checkout "$BRANCH_NAME" -- design/JOURNAL.md
+  # Run journal merge steps (see 8d below)
+  # Commit merge result to workspace main
+  # Mark 8d as complete — skip the 8d block below
+
+git -C "$WORKSPACE" push  # single push for all workspace-main commits
+
+git -C "$WORKSPACE" checkout "$BRANCH_NAME"
+git -C "$WORKSPACE" stash pop  # only if stashed above
+```
+
+### 8b — Project-routed artifact promotion (ADRs, specs)
+
+```bash
+for each project-routed artifact:
+  mkdir -p "$PROJECT/<dest>/"
+  cp "$WORKSPACE/<artifact-file>" "$PROJECT/<dest>/"
+  git -C "$PROJECT" add "<dest>/"
+  git -C "$PROJECT" commit -m "feat: promote <type> from $BRANCH_NAME"
+  git -C "$PROJECT" push  # non-fatal if fails; report exit code
+```
+
+### 8c — Spec cleanup (only if 8b push exit code was 0)
+
+If 8b push failed, skip entirely — workspace copy is the only remaining copy.
+
+```bash
+rm -rf "$WORKSPACE/specs/$BRANCH_NAME/"
+git -C "$WORKSPACE" add -A
+git -C "$WORKSPACE" commit -m "chore($BRANCH_NAME): remove promoted specs from staging"
+git -C "$WORKSPACE" push
+```
+
+### 8d — Journal merge
+
+Uses `$DESIGN_REPO` (set in Step 3) and `$PROJECT_SHA` (set in Step 1).
+
+**⚠️ Branch context matters:** When `$DESIGN_REPO_KEY = workspace`, the merge MUST
+happen during the 8a main-visit (see 8a above) — not here. For `$DESIGN_REPO_KEY = project`,
+run the full merge below on the project epic branch (included in the PR).
+
+Steps:
+1. Read baseline: `git -C "$DESIGN_REPO" show "$PROJECT_SHA":DESIGN.md`
+2. Read current `$DESIGN_REPO/DESIGN.md`
+3. Apply journal narrative per `§Section`, preserving independent main-branch changes
+4. Write merged result
+5. Post-merge verification: re-read each `§Section`; present to user (`[A]` accept,
+   `[R]` redo, `[X]` abort) before committing
+6. Commit and push:
+   ```bash
+   git -C "$DESIGN_REPO" add DESIGN.md
+   git -C "$DESIGN_REPO" commit -m "docs($BRANCH_NAME): apply design journal"
+   git -C "$DESIGN_REPO" push
+   ```
+
+If journal merge fails: prompt user before continuing to issue close.
+
+### 8e — Spec posting
+
+Post selected specs (from Step 6) as collapsible comments on the GitHub issue.
+
+### 8f — Issue close
+
+Only if tracking enabled and `$ISSUE_N` is non-empty:
+```bash
+[ -n "$ISSUE_N" ] && gh issue close "$ISSUE_N" --repo "$OWNER_REPO"
+```
+
+### 8g — Offer publish-blog
+
+If blog entries were staged to workspace, offer: "Publish blog entries now? (y/n)"
+
+### 8h — Final report
+
+```
+✅ ADRs → project
+✅ Specs → project
+✅ Blog → workspace
+✅ Plans → attic
+✅ Journal merged → DESIGN.md (N sections)
+✅ Specs posted to #N, issue closed
+❌ Push failed — <path>. Run: git -C <path> push
+```
+
+### 8i — Offer hygiene scan
+
+"Run branch hygiene scan? Checks Flyway conflicts, unmerged code, stale branches. (y/n)"
+
+### Step path (alternative to all-at-once)
+
+If user chose "step" in Step 7:
+
+- Phase 1: Artifact routing — confirm, execute, report → "Continue to journal merge? (y/n)"
+- Phase 2: Journal merge — show each `§Section` before/after, confirm → "Continue to GitHub posting? (y/n)"
+- Phase 3: Spec posting, issue close, publish-blog offer → "Continue to branch cleanup? (y/n)"
+- Phase 4: EPIC-CLOSED.md and return to main.
+
+---
+
+## Step 9 — Mark closed
+
+```bash
+CLOSE_DATE=$(date +%Y-%m-%d)
+DELETE_DATE=$(date -v +14d +%Y-%m-%d 2>/dev/null || date -d "+14 days" +%Y-%m-%d)
+
+cat > "$WORKSPACE/EPIC-CLOSED.md" << EOF
+# Branch Closed — $BRANCH_NAME
+**Date:** $CLOSE_DATE
+**Issue:** #$ISSUE_N
+**Scheduled for deletion:** $DELETE_DATE
+EOF
+
+git -C "$WORKSPACE" add EPIC-CLOSED.md
+git -C "$WORKSPACE" commit -m "docs($BRANCH_NAME): mark closed, deletion due $DELETE_DATE"
+git -C "$WORKSPACE" push
+```
+
+Branches are **not deleted**. `EPIC-CLOSED.md` is the signal for hygiene scan cleanup.
+
+---
+
+## Step 10 — Return to main
+
+```
+Return both repos to main? (y/n)
+```
+
+If y:
+```bash
+git -C "$PROJECT" checkout main
+git -C "$WORKSPACE" checkout main
+```
+
+Check remote ahead; prompt before `pull --rebase`. Not automatic.

--- a/work-end/SKILL.md
+++ b/work-end/SKILL.md
@@ -25,7 +25,13 @@ WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*
 
 ## Pre-conditions
 
-Check in order before proceeding:
+Resolve paths and read current branch, then check in order:
+
+```bash
+PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+CURRENT_WORKSPACE=$(git -C "$WORKSPACE" branch --show-current)
+```
 
 1. **If `$WORKSPACE/design/.paused` exists** → hard stop.
    "You have a paused branch. Invoke `work-resume` first, then `work-end`."
@@ -190,8 +196,12 @@ failure prompts the user before continuing to issue close.
 ### 8a — Batch workspace-main operations (single main-visit)
 
 ```bash
-# Stash any uncommitted workspace changes
-git -C "$WORKSPACE" status --short | grep -q . && git -C "$WORKSPACE" stash
+# Capture stash ref if workspace has uncommitted changes
+WS_STASH_8A=none
+if git -C "$WORKSPACE" status --short | grep -q .; then
+  stash_out=$(git -C "$WORKSPACE" stash)
+  echo "$stash_out" | grep -q "Saved working" && WS_STASH_8A="stash@{0}"
+fi
 
 git -C "$WORKSPACE" checkout main
 git -C "$WORKSPACE" pull --rebase origin main
@@ -212,18 +222,26 @@ if plans exist:
   git -C "$WORKSPACE" add -A
   git -C "$WORKSPACE" commit -m "archive($BRANCH_NAME): move plans to attic"
 
-# If DESIGN_REPO = workspace: perform journal merge here while on workspace main
-# (see 8d note — merge must happen on main, not on epic branch)
-if [ "$DESIGN_REPO_KEY" = "workspace" ]:
+# WORKSPACE DESIGN REPO CASE: journal merge must happen here on main, not on the epic branch.
+# Commits to the epic branch are discarded at close — the merge must land on workspace main.
+if [ "$DESIGN_REPO_KEY" = "workspace" ]; then
+  # Cherry-pick JOURNAL.md from the epic branch, then run the journal merge sub-procedure
+  # (same steps as 8d below: baseline read, current read, apply journal, verify, commit)
   git -C "$WORKSPACE" checkout "$BRANCH_NAME" -- design/JOURNAL.md
-  # Run journal merge steps (see 8d below)
-  # Commit merge result to workspace main
-  # Mark 8d as complete — skip the 8d block below
+  # [execute 8d merge steps here — baseline=$PROJECT_SHA, target=$WORKSPACE/DESIGN.md]
+  git -C "$WORKSPACE" add DESIGN.md
+  git -C "$WORKSPACE" commit -m "docs($BRANCH_NAME): apply design journal"
+  # 8d is now complete for the workspace case — skip the 8d block when DESIGN_REPO_KEY=workspace
+fi
 
 git -C "$WORKSPACE" push  # single push for all workspace-main commits
 
 git -C "$WORKSPACE" checkout "$BRANCH_NAME"
-git -C "$WORKSPACE" stash pop  # only if stashed above
+# Use the captured ref, not bare stash pop
+if [ "$WS_STASH_8A" != "none" ]; then
+  git -C "$WORKSPACE" stash pop "$WS_STASH_8A" 2>/dev/null \
+    || echo "⚠️ Workspace stash pop failed ($WS_STASH_8A) — resolve manually"
+fi
 ```
 
 ### 8b — Project-routed artifact promotion (ADRs, specs)
@@ -316,18 +334,22 @@ If user chose "step" in Step 7:
 
 ## Step 9 — Mark closed
 
+`EPIC-CLOSED.md` lives in `$WORKSPACE/design/` alongside `.meta` and `JOURNAL.md`.
+This is committed to the workspace **epic branch** (not main), so the hygiene scan
+must traverse epic branches to find it — which it already does to check for `.meta`.
+
 ```bash
 CLOSE_DATE=$(date +%Y-%m-%d)
 DELETE_DATE=$(date -v +14d +%Y-%m-%d 2>/dev/null || date -d "+14 days" +%Y-%m-%d)
 
-cat > "$WORKSPACE/EPIC-CLOSED.md" << EOF
+cat > "$WORKSPACE/design/EPIC-CLOSED.md" << EOF
 # Branch Closed — $BRANCH_NAME
 **Date:** $CLOSE_DATE
 **Issue:** #$ISSUE_N
 **Scheduled for deletion:** $DELETE_DATE
 EOF
 
-git -C "$WORKSPACE" add EPIC-CLOSED.md
+git -C "$WORKSPACE" add design/EPIC-CLOSED.md
 git -C "$WORKSPACE" commit -m "docs($BRANCH_NAME): mark closed, deletion due $DELETE_DATE"
 git -C "$WORKSPACE" push
 ```

--- a/work-end/SKILL.md
+++ b/work-end/SKILL.md
@@ -116,6 +116,42 @@ subsequent steps.
 
 ---
 
+## Step 3b — Pre-close sweep
+
+Before inventorying artifacts, verify the branch leaves nothing behind. Present
+this checklist:
+
+```
+Pre-close sweep — create before presenting the close plan?
+
+[x] 1  write-blog     capture any work on this branch worth a diary entry
+[x] 2  adr            record any significant architectural decisions without a formal ADR
+[x] 3  protocol sweep formalise any project rules established or re-enforced this branch
+[x] 4  forage sweep   check for gotchas, techniques, or undocumented behaviours
+
+Type numbers to toggle, "all" to toggle all, or "go" to proceed:
+```
+
+Defaults: all four on. The user may deselect any that clearly don't apply (e.g. "go"
+immediately if the branch was a one-line typo fix). Do not auto-skip — the point is
+to make the decision explicit.
+
+Run checked items in this order:
+1. **Forage sweep** — while context is full; findings may feed the blog entry
+2. **Protocol sweep** — while context is full (invoke `protocol` skill with `SWEEP` operation)
+3. **adr** — invoke `adr` skill for each candidate identified
+4. **write-blog** — last, so it can synthesise the full branch narrative including any forage/protocol submissions
+
+**Why this step exists:** Step 4 inventories artifacts that *were written*. Without this
+sweep, the close plan accurately reports "blog: no new entries" when it should say "blog:
+no new entries (and none were considered)." The sweep converts the inventory from a
+snapshot into a verified statement. Only after this step is complete does the close plan
+accurately reflect what the branch leaves behind.
+
+After all checked items complete, proceed to Step 4.
+
+---
+
 ## Step 4 — Inventory artifacts
 
 ```bash

--- a/work-end/commands/work-end.md
+++ b/work-end/commands/work-end.md
@@ -1,0 +1,5 @@
+---
+description: "Close the current branch: promote artifacts, merge journal, close issue, return to main."
+---
+
+Invoke the `work-end` skill.

--- a/work-pause/SKILL.md
+++ b/work-pause/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: work-pause
 description: >
-  Save the current branch context and switch both repos to main, so you can
-  work on something else without losing state. Records a .paused marker on
-  workspace main. Only one paused branch at a time. Use work-resume to return.
+  Use when interrupting current branch work to switch to something else — user
+  says "work-pause", "pause this work", or "switch to a different issue". Only
+  one paused branch at a time. Pair with work-resume to restore.
 ---
 
 # work-pause

--- a/work-pause/SKILL.md
+++ b/work-pause/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: work-pause
+description: >
+  Save the current branch context and switch both repos to main, so you can
+  work on something else without losing state. Records a .paused marker on
+  workspace main. Only one paused branch at a time. Use work-resume to return.
+---
+
+# work-pause
+
+Saves context, stashes any uncommitted changes, records a pause marker on
+workspace main, and switches both repos to main.
+
+**Only one paused branch at a time.** If `.paused` already exists, this skill
+stops immediately.
+
+---
+
+## Path Resolution (run first, always)
+
+```bash
+PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+```
+
+---
+
+## Step 0 — Resolve paths
+
+Read `$PROJECT` and `$WORKSPACE` from CLAUDE.md (see Path Resolution above).
+
+---
+
+## Step 1 — Validate state
+
+```bash
+ls "$WORKSPACE/design/.meta" 2>/dev/null || { echo "No .meta found — not on a working branch."; exit 1; }
+ls "$WORKSPACE/design/.paused" 2>/dev/null && { echo "⚠️ Already paused. Use work-resume first."; exit 1; }
+
+BRANCH_NAME=$(grep "^branch:" "$WORKSPACE/design/.meta" | sed 's/branch: //')
+```
+
+Must be on a branch where `$WORKSPACE/design/.meta` exists.
+If `.paused` already exists: hard stop — only one paused branch at a time.
+
+---
+
+## Step 2 — Handle uncommitted changes
+
+```bash
+PROJECT_DIRTY=$(git -C "$PROJECT" status --short | grep -c . || echo 0)
+WORKSPACE_DIRTY=$(git -C "$WORKSPACE" status --short | grep -c . || echo 0)
+```
+
+If either is dirty:
+```
+Uncommitted changes found in:
+  project:   <N files>
+  workspace: <N files>
+Stash them? (y/n)
+  n → abort (commit or discard changes first)
+```
+
+If y:
+```bash
+STASH_PROJECT=none
+STASH_WORKSPACE=none
+[ "$PROJECT_DIRTY" -gt 0 ] && git -C "$PROJECT" stash && STASH_PROJECT="stash@{0}"
+[ "$WORKSPACE_DIRTY" -gt 0 ] && git -C "$WORKSPACE" stash && STASH_WORKSPACE="stash@{0}"
+```
+
+**Warning to user:** If you run `git stash` or `git stash pop` manually on either
+repo before resuming, the recorded stash position will shift and restoration will
+fail. Use `work-resume` before any manual stash operations on these repos.
+
+---
+
+## Step 3 — Record pause in .meta (atomic with Step 4)
+
+```bash
+PAUSE_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+cat >> "$WORKSPACE/design/.meta" << EOF
+paused: true
+paused-at: $PAUSE_TS
+stash-project: $STASH_PROJECT
+stash-workspace: $STASH_WORKSPACE
+EOF
+
+git -C "$WORKSPACE" add design/.meta
+git -C "$WORKSPACE" commit -m "chore($BRANCH_NAME): pause"
+git -C "$WORKSPACE" push
+```
+
+**If push fails: abort before Step 4.** Do not write `.paused` to main.
+This ensures `.paused` on main always corresponds to a committed pause record
+in `.meta` on the branch.
+
+---
+
+## Step 4 — Write .paused to workspace main
+
+```bash
+# Do NOT stash again — workspace stash already on stack from Step 2 if applicable
+git -C "$WORKSPACE" checkout main
+git -C "$WORKSPACE" pull --rebase origin main
+
+mkdir -p "$WORKSPACE/design"
+cat > "$WORKSPACE/design/.paused" << EOF
+branch: $BRANCH_NAME
+paused-at: $PAUSE_TS
+EOF
+
+git -C "$WORKSPACE" add design/.paused
+git -C "$WORKSPACE" commit -m "chore: pause marker for $BRANCH_NAME"
+git -C "$WORKSPACE" push
+```
+
+---
+
+## Step 5 — Switch project repo to main
+
+```bash
+git -C "$PROJECT" checkout main
+```
+
+Check if remote is ahead — prompt before pulling. Not automatic.
+
+---
+
+## Step 6 — Confirm
+
+```
+⏸  Paused: <branch-name>  Both repos now on main.
+   Stash: project=<stash@{N} | none>  workspace=<stash@{N} | none>
+
+Resume with: work-resume
+```

--- a/work-pause/SKILL.md
+++ b/work-pause/SKILL.md
@@ -48,8 +48,9 @@ If `.paused` already exists: hard stop — only one paused branch at a time.
 ## Step 2 — Handle uncommitted changes
 
 ```bash
-PROJECT_DIRTY=$(git -C "$PROJECT" status --short | grep -c . || echo 0)
-WORKSPACE_DIRTY=$(git -C "$WORKSPACE" status --short | grep -c . || echo 0)
+# Use wc -l — grep -c exits 1 on no-match and outputs "0", causing || echo 0 to produce "0\n0"
+PROJECT_DIRTY=$(git -C "$PROJECT" status --short | wc -l | tr -d ' ')
+WORKSPACE_DIRTY=$(git -C "$WORKSPACE" status --short | wc -l | tr -d ' ')
 ```
 
 If either is dirty:
@@ -65,9 +66,21 @@ If y:
 ```bash
 STASH_PROJECT=none
 STASH_WORKSPACE=none
-[ "$PROJECT_DIRTY" -gt 0 ] && git -C "$PROJECT" stash && STASH_PROJECT="stash@{0}"
-[ "$WORKSPACE_DIRTY" -gt 0 ] && git -C "$WORKSPACE" stash && STASH_WORKSPACE="stash@{0}"
+
+if [ "$PROJECT_DIRTY" -gt 0 ]; then
+  stash_out=$(git -C "$PROJECT" stash)
+  echo "$stash_out" | grep -q "Saved working" && STASH_PROJECT="stash@{0}"
+fi
+
+if [ "$WORKSPACE_DIRTY" -gt 0 ]; then
+  stash_out=$(git -C "$WORKSPACE" stash)
+  echo "$stash_out" | grep -q "Saved working" && STASH_WORKSPACE="stash@{0}"
+fi
 ```
+
+The stash output is checked to confirm something was actually saved before recording
+`stash@{0}` — `git stash` exits 0 even when there is nothing to stash ("No local changes
+to save"), which would otherwise record a stale reference pointing to a previous stash.
 
 **Warning to user:** If you run `git stash` or `git stash pop` manually on either
 repo before resuming, the recorded stash position will shift and restoration will

--- a/work-pause/commands/work-pause.md
+++ b/work-pause/commands/work-pause.md
@@ -1,0 +1,5 @@
+---
+description: "Save context and switch both repos to main so you can work on something else."
+---
+
+Invoke the `work-pause` skill.

--- a/work-resume/SKILL.md
+++ b/work-resume/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: work-resume
 description: >
-  Resume a paused working branch. Reads the .paused marker from workspace main,
-  switches both repos back to the branch, removes the pause marker, restores
-  stashed changes, and runs pre-checks. Must be invoked from main (or any state
-  where .paused exists on workspace main).
+  Use when returning to a paused branch — user says "work-resume", "resume",
+  or "go back to that branch". Requires a .paused marker on workspace main
+  (created by work-pause). Must be invoked from main.
 ---
 
 # work-resume

--- a/work-resume/SKILL.md
+++ b/work-resume/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: work-resume
+description: >
+  Resume a paused working branch. Reads the .paused marker from workspace main,
+  switches both repos back to the branch, removes the pause marker, restores
+  stashed changes, and runs pre-checks. Must be invoked from main (or any state
+  where .paused exists on workspace main).
+---
+
+# work-resume
+
+Resumes a paused branch: switches both repos back, removes the pause marker,
+restores stashed changes, runs pre-checks.
+
+---
+
+## Path Resolution (run first, always)
+
+```bash
+PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+```
+
+---
+
+## Step 0 — Resolve paths
+
+Read `$PROJECT` and `$WORKSPACE` from CLAUDE.md (see Path Resolution above).
+
+---
+
+## Step 1 — Check .paused
+
+```bash
+cat "$WORKSPACE/design/.paused" 2>/dev/null \
+  || { echo "Nothing to resume — no .paused found."; exit 1; }
+
+RESUME_BRANCH=$(grep "^branch:" "$WORKSPACE/design/.paused" | sed 's/branch: //')
+PAUSED_AT=$(grep "^paused-at:" "$WORKSPACE/design/.paused" | sed 's/paused-at: //')
+```
+
+---
+
+## Step 2 — Stale check
+
+Verify the branch still exists in both repos:
+
+```bash
+git -C "$WORKSPACE" branch -a | grep -q "$RESUME_BRANCH" \
+  || echo "⚠️ $RESUME_BRANCH not found in workspace"
+git -C "$PROJECT" branch -a | grep -q "$RESUME_BRANCH" \
+  || echo "⚠️ $RESUME_BRANCH not found in project"
+```
+
+If missing from either repo:
+- `[D]` Discard `.paused` and clean up — remove the marker file and commit
+- `[A]` Abort — leave state as-is for manual investigation
+
+---
+
+## Step 3 — Switch both repos to epic branch
+
+Use Branch Switch Helper with `$RESUME_BRANCH`. Prompt before remote pull.
+
+```bash
+git -C "$PROJECT" checkout "$RESUME_BRANCH"
+git -C "$WORKSPACE" checkout "$RESUME_BRANCH"
+
+PROJECT_BEHIND=$(git -C "$PROJECT" rev-list HEAD..origin/"$RESUME_BRANCH" --count 2>/dev/null || echo 0)
+WORKSPACE_BEHIND=$(git -C "$WORKSPACE" rev-list HEAD..origin/"$RESUME_BRANCH" --count 2>/dev/null || echo 0)
+if [ "$PROJECT_BEHIND" -gt 0 ] || [ "$WORKSPACE_BEHIND" -gt 0 ]; then
+  echo "Remote has new commits (+${PROJECT_BEHIND} project, +${WORKSPACE_BEHIND} workspace)."
+  echo "Incorporate now with pull --rebase? (y/n)"
+fi
+```
+
+---
+
+## Step 4 — Remove .paused from workspace main
+
+```bash
+# Stash any uncommitted workspace changes on the epic branch
+git -C "$WORKSPACE" status --short | grep -q . && git -C "$WORKSPACE" stash
+
+git -C "$WORKSPACE" checkout main
+git -C "$WORKSPACE" pull --rebase origin main
+rm "$WORKSPACE/design/.paused"
+git -C "$WORKSPACE" add -A
+git -C "$WORKSPACE" commit -m "chore: resume $RESUME_BRANCH, remove pause marker"
+git -C "$WORKSPACE" push
+
+git -C "$WORKSPACE" checkout "$RESUME_BRANCH"
+git -C "$WORKSPACE" stash pop 2>/dev/null || true  # only if stashed above
+```
+
+---
+
+## Step 5 — Restore stashed changes
+
+Read stash references from `.meta` and pop each using its recorded position:
+
+```bash
+STASH_PROJECT=$(grep "^stash-project:" "$WORKSPACE/design/.meta" | sed 's/stash-project: //')
+STASH_WORKSPACE=$(grep "^stash-workspace:" "$WORKSPACE/design/.meta" | sed 's/stash-workspace: //')
+
+# Use the recorded stash reference — do NOT use bare stash pop (pops wrong
+# stash if the stack shifted since pause time)
+[ "$STASH_PROJECT" != "none" ] && \
+  git -C "$PROJECT" stash pop "$STASH_PROJECT" 2>/dev/null \
+  || { [ "$STASH_PROJECT" != "none" ] \
+       && echo "⚠️ Project stash pop failed ($STASH_PROJECT) — resolve manually"; }
+
+[ "$STASH_WORKSPACE" != "none" ] && \
+  git -C "$WORKSPACE" stash pop "$STASH_WORKSPACE" 2>/dev/null \
+  || { [ "$STASH_WORKSPACE" != "none" ] \
+       && echo "⚠️ Workspace stash pop failed ($STASH_WORKSPACE) — resolve manually"; }
+```
+
+If stash pop fails: warn and continue. Do not abort — the branch is already restored
+and the user can resolve stash conflicts manually.
+
+---
+
+## Step 6 — Clear pause flags from .meta
+
+```bash
+sed -i '' \
+  '/^paused:/d; /^paused-at:/d; /^paused-issue:/d; /^stash-project:/d; /^stash-workspace:/d' \
+  "$WORKSPACE/design/.meta"
+git -C "$WORKSPACE" add design/.meta
+git -C "$WORKSPACE" commit -m "chore($RESUME_BRANCH): clear pause flags from .meta"
+git -C "$WORKSPACE" push
+```
+
+---
+
+## Step 7 — Surface context
+
+Compute how long the branch was paused:
+```bash
+# $PAUSED_AT read from .paused in Step 1
+echo "Paused at: $PAUSED_AT"
+```
+
+```
+▶  Resumed: <branch-name>  Issue: #<N>  Paused <duration> ago
+   Stash restored: <yes | no | conflict — resolve manually>
+```
+
+---
+
+## Step 8 — Run pre-checks
+
+Run Steps 0, 2, 3, 11 from work-start:
+- **Step 0**: Path resolution (already done)
+- **Step 2**: Platform coherence — re-read platform doc, run five coherence questions
+- **Step 3**: Relevant protocols — scan and read applicable rules
+- **Step 11**: IntelliJ MCPs — call both; hard stop if unavailable
+
+Skip all branch creation steps — the branch already exists.

--- a/work-resume/SKILL.md
+++ b/work-resume/SKILL.md
@@ -46,9 +46,10 @@ PAUSED_AT=$(grep "^paused-at:" "$WORKSPACE/design/.paused" | sed 's/paused-at: /
 Verify the branch still exists in both repos:
 
 ```bash
-git -C "$WORKSPACE" branch -a | grep -q "$RESUME_BRANCH" \
+# Use rev-parse --verify for exact match — grep would match partial branch names
+git -C "$WORKSPACE" rev-parse --verify "$RESUME_BRANCH" &>/dev/null \
   || echo "⚠️ $RESUME_BRANCH not found in workspace"
-git -C "$PROJECT" branch -a | grep -q "$RESUME_BRANCH" \
+git -C "$PROJECT" rev-parse --verify "$RESUME_BRANCH" &>/dev/null \
   || echo "⚠️ $RESUME_BRANCH not found in project"
 ```
 
@@ -79,8 +80,12 @@ fi
 ## Step 4 — Remove .paused from workspace main
 
 ```bash
-# Stash any uncommitted workspace changes on the epic branch
-git -C "$WORKSPACE" status --short | grep -q . && git -C "$WORKSPACE" stash
+# Capture stash ref if workspace has uncommitted changes on the epic branch
+STEP4_STASH=none
+if git -C "$WORKSPACE" status --short | grep -q .; then
+  stash_out=$(git -C "$WORKSPACE" stash)
+  echo "$stash_out" | grep -q "Saved working" && STEP4_STASH="stash@{0}"
+fi
 
 git -C "$WORKSPACE" checkout main
 git -C "$WORKSPACE" pull --rebase origin main
@@ -90,7 +95,11 @@ git -C "$WORKSPACE" commit -m "chore: resume $RESUME_BRANCH, remove pause marker
 git -C "$WORKSPACE" push
 
 git -C "$WORKSPACE" checkout "$RESUME_BRANCH"
-git -C "$WORKSPACE" stash pop 2>/dev/null || true  # only if stashed above
+# Use the recorded ref, not bare stash pop (consistent with Step 5 principle)
+if [ "$STEP4_STASH" != "none" ]; then
+  git -C "$WORKSPACE" stash pop "$STEP4_STASH" 2>/dev/null \
+    || echo "⚠️ Workspace stash pop failed ($STEP4_STASH) — resolve manually"
+fi
 ```
 
 ---
@@ -105,15 +114,17 @@ STASH_WORKSPACE=$(grep "^stash-workspace:" "$WORKSPACE/design/.meta" | sed 's/st
 
 # Use the recorded stash reference — do NOT use bare stash pop (pops wrong
 # stash if the stack shifted since pause time)
-[ "$STASH_PROJECT" != "none" ] && \
-  git -C "$PROJECT" stash pop "$STASH_PROJECT" 2>/dev/null \
-  || { [ "$STASH_PROJECT" != "none" ] \
-       && echo "⚠️ Project stash pop failed ($STASH_PROJECT) — resolve manually"; }
+if [ "$STASH_PROJECT" != "none" ]; then
+  if ! git -C "$PROJECT" stash pop "$STASH_PROJECT" 2>/dev/null; then
+    echo "⚠️ Project stash pop failed ($STASH_PROJECT) — resolve manually"
+  fi
+fi
 
-[ "$STASH_WORKSPACE" != "none" ] && \
-  git -C "$WORKSPACE" stash pop "$STASH_WORKSPACE" 2>/dev/null \
-  || { [ "$STASH_WORKSPACE" != "none" ] \
-       && echo "⚠️ Workspace stash pop failed ($STASH_WORKSPACE) — resolve manually"; }
+if [ "$STASH_WORKSPACE" != "none" ]; then
+  if ! git -C "$WORKSPACE" stash pop "$STASH_WORKSPACE" 2>/dev/null; then
+    echo "⚠️ Workspace stash pop failed ($STASH_WORKSPACE) — resolve manually"
+  fi
+fi
 ```
 
 If stash pop fails: warn and continue. Do not abort — the branch is already restored
@@ -136,10 +147,10 @@ git -C "$WORKSPACE" push
 
 ## Step 7 — Surface context
 
-Compute how long the branch was paused:
 ```bash
+# Extract issue number from .meta (read once here, not re-derived later)
+ISSUE_N=$(grep "^issue:" "$WORKSPACE/design/.meta" | sed 's/issue: //')
 # $PAUSED_AT read from .paused in Step 1
-echo "Paused at: $PAUSED_AT"
 ```
 
 ```

--- a/work-resume/commands/work-resume.md
+++ b/work-resume/commands/work-resume.md
@@ -1,0 +1,5 @@
+---
+description: "Restore a paused branch: switch both repos back, restore stash, run pre-checks."
+---
+
+Invoke the `work-resume` skill.

--- a/work-start/SKILL.md
+++ b/work-start/SKILL.md
@@ -2,208 +2,309 @@
 name: work-start
 description: >
   MUST be invoked at the start of every piece of work — user says "work-start",
-  or it appears as the first instruction in a work-item prompt. Runs four
-  mandatory checks before any design or implementation begins: reads the
-  platform doc and runs the coherence protocol against the described work,
-  checks relevant protocols, confirms an issue exists, and verifies IntelliJ
-  MCPs with a hard stop if unavailable. These checks are NOT optional and must
-  NOT be skipped even for small changes. Failure to run this skill before
-  starting work risks violating platform conventions, missing relevant rules,
-  working without an issue, or silently degrading to bash when IntelliJ is
-  unavailable.
+  or it appears as the first instruction in a work-item prompt. Detects current
+  branch state, creates a branch if needed, scaffolds .meta + JOURNAL.md, and
+  runs pre-checks before any design or implementation begins. Replaces the
+  former two-step "work-start + /epic begin" workflow — branch creation is now
+  integrated. These checks are NOT optional and must NOT be skipped even for
+  small changes.
 ---
 
-# Work Start
+# work-start
 
-Four mandatory checks before any design or implementation begins.
-**All four must complete before proceeding.**
+Single entry point for all work. Detects state, creates or resumes a branch,
+runs pre-checks. **Never skip this skill — even for small changes.**
+
+---
+
+## Path Resolution (run first, always)
+
+```bash
+PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
+WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
+```
+
+All file paths and git commands below use `$PROJECT` and `$WORKSPACE`. Never
+use bare `git` without `-C <path>`. Never rely on CWD.
 
 ---
 
 ## Branch Switch Helper
 
-When switching both repos to a branch (at session start, after epic begin, or on return from pause), always use this atomic procedure — never switch one repo and forget the other:
+Use any time both repos must switch branches together. Never switch one alone.
 
 ```bash
-# Read project path from CLAUDE.md
-PROJECT=$(grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //')
-WORKSPACE=$(grep "^\*\*Workspace:\*\*" CLAUDE.md | head -1 | sed 's/.*`\(.*\)`.*/\1/')
-
-# Switch both repos atomically
 git -C "$PROJECT" checkout <branch>
 git -C "$WORKSPACE" checkout <branch>
 
-# Check if remote is ahead — prompt before incorporating upstream changes
 PROJECT_BEHIND=$(git -C "$PROJECT" rev-list HEAD..origin/<branch> --count 2>/dev/null || echo 0)
 WORKSPACE_BEHIND=$(git -C "$WORKSPACE" rev-list HEAD..origin/<branch> --count 2>/dev/null || echo 0)
-
 if [ "$PROJECT_BEHIND" -gt 0 ] || [ "$WORKSPACE_BEHIND" -gt 0 ]; then
-  echo "Remote has new commits: project +${PROJECT_BEHIND}, workspace +${WORKSPACE_BEHIND}"
-  echo "Incorporate now with pull --rebase? You may not be ready for upstream changes. (y/n)"
-  # Wait for user response before pulling
+  echo "Remote has new commits (+${PROJECT_BEHIND} project, +${WORKSPACE_BEHIND} workspace)."
+  echo "Incorporate now with pull --rebase? (y/n)"
+  # Wait — user may not be ready for upstream changes
 fi
-# If yes: git -C "$PROJECT" pull --rebase origin <branch>
-#          git -C "$WORKSPACE" pull --rebase origin <branch>
 
-# Verify alignment
 PROJECT_BRANCH=$(git -C "$PROJECT" branch --show-current)
 WORKSPACE_BRANCH=$(git -C "$WORKSPACE" branch --show-current)
-if [ "$PROJECT_BRANCH" != "$WORKSPACE_BRANCH" ]; then
-  echo "⚠️  Branch mismatch after switch: project=$PROJECT_BRANCH workspace=$WORKSPACE_BRANCH"
-  echo "    Manual alignment required before proceeding."
-  exit 1
-fi
+[ "$PROJECT_BRANCH" = "$WORKSPACE_BRANCH" ] \
+  || { echo "⚠️ Mismatch after switch. Manual alignment required."; exit 1; }
 echo "✅ Both repos on: $PROJECT_BRANCH"
 ```
 
-**Use this procedure any time both repos need to move together.** Never run `git checkout` on one repo alone without immediately doing the same on the other.
+If helper fails (branch absent in one repo, network error): hard stop with
+instructions. Do not loop.
 
 ---
 
-## 0 — Check Epic State
+## Detection
 
-Before anything else, check whether a workspace epic is in progress:
+Resolve paths first. Then read:
 
 ```bash
-cat design/.meta 2>/dev/null
-git branch --show-current
+META_BRANCH=$(grep "^branch:" "$WORKSPACE/design/.meta" 2>/dev/null | sed 's/branch: //')
+CURRENT_WORKSPACE=$(git -C "$WORKSPACE" branch --show-current)
+CURRENT_PROJECT=$(git -C "$PROJECT" branch --show-current)
 ```
 
-Also read the project repo branch:
-```bash
-grep "add-dir" CLAUDE.md | head -1 | sed 's/.*add-dir //'
-# then:
-git -C <project-path> branch --show-current
-```
-
-| State | Action |
-|-------|--------|
-| `.meta` exists, both repos on same branch | Surface branch name and issue number(s) — you are mid-branch |
-| `.meta` exists, branches differ | **Stop** — branch mismatch. Use the Branch Switch Helper above to align both repos, then re-run work-start |
-| `.meta` on main branch | **Stop** — orphaned `.meta`. Run `/epic` to clean up before starting work |
-| No `.meta`, both on main | **Stop** — no active branch. See below before continuing |
-
-**If no active branch (no `.meta`, both on main):**
+Check in order — first match wins:
 
 ```
-⚠️  No active branch detected. Before proceeding, choose one:
+1. $WORKSPACE/design/.paused exists in the working tree
+   → Hard stop. "Paused branch detected. Invoke work-resume first."
 
-  1. Branch work  → invoke /epic begin (same workflow for all branch work;
-                    epic branches cover 1–N issues, issue branches cover 1 issue)
-  2. Exploratory  → invoke superpowers:using-git-worktrees
-  3. Main work    → confirm explicitly before continuing
+2. $WORKSPACE/design/.meta exists, AND
+   META_BRANCH == CURRENT_WORKSPACE == CURRENT_PROJECT (all three match)
+   → Resume path.
 
-Do not proceed to steps 1–4 below until one of these is resolved.
-```
+3. $WORKSPACE/design/.meta exists, CURRENT_WORKSPACE == main
+   (orphaned — .meta on main, regardless of project branch)
+   → Hard stop. "Invoke work-end to complete or discard the abandoned branch."
+   *** Checked BEFORE state 4 — orphaned also satisfies "branches misaligned"
+   so state 4 would fire incorrectly and attempt to switch to a deleted branch. ***
 
-Wait for the user to respond before continuing.
+4. $WORKSPACE/design/.meta exists, branches misaligned
+   (META_BRANCH != CURRENT_WORKSPACE or CURRENT_PROJECT, and not orphaned)
+   → Invoke Branch Switch Helper inline.
+     If helper fails → hard stop with manual instructions (no loop).
 
-**Do NOT output the work-start summary. Do NOT say "proceeding to brainstorming". Do NOT continue to steps 1–4.** This is a hard gate — the session stops here until the user picks one of the three options above.
+5. CURRENT_WORKSPACE == main, no .meta, no .paused
+   → New branch path (Steps 0–12 below).
 
-**After the user responds:**
-- Option 1 (branch work): wait for `/epic begin` to complete, then resume work-start from Step 1.
-- Option 2 (exploratory): wait for `superpowers:using-git-worktrees` to complete, then resume work-start from Step 1.
-- Option 3 (confirmed main): accept the confirmation and proceed to Steps 1–4 normally. Include `⚠️ Working on main (explicitly confirmed)` in the final work-start report.
-
-**If mid-branch, include in the work-start report:**
-```
-⚡ Active branch: <branch-name>  Issue(s): #<N>
-   Project branch: <branch>  Workspace branch: <branch>
+6. On non-main branch, no .meta
+   → "You are on <branch> with no branch scaffold.
+      Continue here (y) or switch to main (n)?"
+      y → run Steps 0, 2, 3, 11 only. No scaffold created. Skip Step 4 —
+            no .meta exists to record the issue. This path is for hotfixes or
+            docs-only work that will not use work-end. If work-end is needed
+            later, create .meta manually first.
+      n → Branch Switch Helper to main, re-run detection.
 ```
 
 ---
 
-## 1 — Read the Platform Doc and Run the Coherence Protocol
+## New Branch Path
+
+### Step 0 — Resolve paths
+
+Read `$PROJECT` and `$WORKSPACE` from CLAUDE.md (see Path Resolution above).
+
+### Step 1 — Work description
+
+Use the invocation argument if provided. Otherwise prompt:
+> "Describe the work in one sentence."
+
+### Step 2 — Platform coherence
 
 Locate the platform doc:
 
 ```bash
-# casehubio
-ls ~/claude/casehub/parent/docs/PLATFORM.md 2>/dev/null
-# Other projects: check CLAUDE.md for platform-doc: key, or docs/PLATFORM.md
+ls "$PROJECT/docs/PLATFORM.md" 2>/dev/null || ls ~/claude/casehub/parent/docs/PLATFORM.md 2>/dev/null
 ```
 
-Read it, then run the Platform Coherence Protocol against the work described
-in this prompt. The protocol asks — answer each one for the specific work:
+Read it. Run the five coherence questions against the work description:
 
-1. **Does this already exist?** Is this capability implemented somewhere in the platform already?
-2. **Is this the right repo?** Would this work more naturally live in a different repo?
+1. **Does this already exist?** Is this capability already implemented somewhere?
+2. **Is this the right repo?** Would this work more naturally live elsewhere?
 3. **Does this create a consolidation opportunity?** Should existing similar code be unified?
-4. **Is it consistent with platform patterns?** Does it follow the module tier structure, naming conventions, and architectural rules?
-5. **Does it need a platform-level doc update?** Will PLATFORM.md, APPLICATIONS.md, or docs/repos/ need updating after this?
+4. **Is it consistent with platform patterns?** Module tier structure, naming conventions, architectural rules?
+5. **Does it need a platform-level doc update?** Will PLATFORM.md or docs/repos/ need updating?
 
-If any answer raises a concern, surface it to the user before proceeding.
+Surface any concerns to the user before proceeding.
 
----
-
-## 2 — Check Relevant Protocols
+### Step 3 — Relevant protocols
 
 ```bash
-ls ~/claude/casehub/parent/docs/protocols/
+ls "$PROJECT/docs/protocols/" 2>/dev/null || ls ~/claude/casehub/parent/docs/protocols/ 2>/dev/null
 ```
 
-Scan the protocol list for any rules relevant to the described work. Common ones to check:
+Read any protocols applicable to the described work. Surface violations before proceeding.
 
+Common signals:
 - Maven coordinate changes → `maven-coordinate-standard.md`, `artifact-rename-propagation.md`
 - Flyway migrations → `flyway-migration-rules.md`, `flyway-version-range-allocation.md`
 - SPI changes → `ledger-spi-propagation.md`, `spi-blocking-reactive-parity.md`
-- Cross-repo deps → `artifact-rename-propagation.md`
 - Module structure → `module-tier-structure.md`, `maven-submodule-folder-naming.md`
 
-Read any that apply. Surface violations or constraints to the user before proceeding.
+### Step 4 — Issue
 
----
-
-## 3 — Confirm an Issue Exists
+If tracking enabled (CLAUDE.md `## Work Tracking` with `Issue tracking: enabled`):
 
 ```bash
-gh issue list --state open --limit 10
+gh issue list --state open --repo <owner/repo> --limit 10
 ```
 
-- If an issue covers this work: note the issue number — every commit must reference it
-- If no issue exists: create one now before proceeding
+- Search for an existing open issue matching the work description.
+- If found: confirm — "Found #N: `<title>`. Use this? (y/n)"
+- If not found: offer to create — wait for result.
+- Record `ISSUE_N` and `ISSUE_TITLE` for Step 5.
+
+If tracking disabled: skip silently.
+
+Do not proceed without resolving this step.
+
+### Step 5 — Branch name
+
+Derive: `issue-NNN-<slug>` (title lowercased, special chars stripped, max 30 chars after prefix).
+
+Show to user, allow override. Guards:
+- Reject `main`, `HEAD`, or any existing branch name in either repo.
+- The issue number (NNN) is the stable key — the slug is a convenience only.
+
+### Step 6 — Flyway V scan
 
 ```bash
-gh issue create --title "..." --body "..."
+git -C "$PROJECT" fetch --all 2>/dev/null || echo "⚠️ No network — scan incomplete"
 ```
 
-Do not proceed without an issue number.
+If network available: scan main + all remote branches for claimed V numbers. Compute
+`next-safe-v = max + 1`. If conflict found: warn, show offending branches, block until acknowledged.
 
----
+Only ask about Flyway if the user described migration work:
+> "Will this branch include database migrations? (y/n)"
+> - y → `FLYWAY_NEXT_V=<next-safe-v>`
+> - explicit n → `FLYWAY_NEXT_V=none`
+> - no answer (default) → `FLYWAY_NEXT_V=unknown`
 
-## 4 — Verify IntelliJ MCPs
+### Step 7 — Create branches (atomic)
+
+```bash
+git -C "$PROJECT" checkout -b <branch-name>
+# If fails → abort (nothing to clean up)
+git -C "$WORKSPACE" checkout -b <branch-name>
+# If fails → git -C "$PROJECT" branch -D <branch-name>, abort, report error
+```
+
+Confirm both commands succeeded before continuing.
+
+### Step 8 — Resolve design routing and SHA baseline
+
+Read routing config (3-layer cascade) for `design` artifact:
+
+**Layer 1 (global default — `~/.claude/CLAUDE.md`):**
+```bash
+grep -A 5 "^## Routing$" "$HOME/.claude/CLAUDE.md" 2>/dev/null \
+  | grep "^\*\*Default destination:\*\*" | sed 's/\*\*Default destination:\*\* *//'
+```
+Valid values: `workspace` or `project`. Anything else: warn, treat as absent.
+
+**Layer 2 (workspace per-artifact — `$WORKSPACE/CLAUDE.md`):**
+```bash
+grep -A 30 "^## Routing$" "$WORKSPACE/CLAUDE.md" 2>/dev/null
+```
+Parse the markdown table for a `design` row. Valid values: `workspace`, `project`.
+
+Layer 2 overrides Layer 1. If neither present: default is `project`.
+
+Apply resolved routing:
+- If `design → workspace`: `DESIGN_REPO="$WORKSPACE"`, baseline = `git -C "$WORKSPACE" rev-parse main`, `DESIGN_REPO_KEY=workspace`
+- If `design → project` (default): `DESIGN_REPO="$PROJECT"`, baseline = `git -C "$PROJECT" rev-parse HEAD`, `DESIGN_REPO_KEY=project`
+
+`DESIGN_REPO_KEY` is stored in `.meta` so work-end can recover it without re-deriving
+from routing config — which may have changed between sessions.
+
+Compute section hashes (single pipe-separated line):
+```bash
+HASHES=$(grep "^## " "$DESIGN_REPO/DESIGN.md" 2>/dev/null \
+  | while read h; do printf "%s:%s|" "$(printf '%s' "$h" | shasum -a 256 | cut -c1-8)" "$h"; done)
+```
+Leave blank if `$DESIGN_REPO/DESIGN.md` does not exist yet.
+
+### Step 9 — Scaffold
+
+```bash
+mkdir -p "$WORKSPACE/design"
+```
+
+Write `$WORKSPACE/design/JOURNAL.md`:
+```markdown
+# Design Journal — <branch-name>
+```
+
+Write `$WORKSPACE/design/.meta`:
+```
+branch: <branch-name>
+project-sha: <baseline SHA from Step 8>
+date: <YYYY-MM-DD>
+issue: <N or blank>
+flyway-next-v: <N | none | unknown>
+design-repo: <workspace | project>
+design-section-hashes: <pipe-separated hash:heading pairs, or blank>
+```
+
+### Step 10 — Commit and push scaffold
+
+```bash
+git -C "$WORKSPACE" add design/JOURNAL.md design/.meta
+git -C "$WORKSPACE" commit -m "init(<branch-name>): scaffold workspace branch"
+git -C "$WORKSPACE" push  # non-fatal if fails; warn and continue
+```
+
+### Step 11 — IntelliJ MCPs
 
 Call `mcp__intellij-index__ide_index_status` and `mcp__intellij__get_project_modules`.
-Do NOT use the `LSP` tool — that is Claude Code's built-in LSP, not IntelliJ.
 
-**If either MCP is unavailable:**
-- Stop immediately
-- Tell the user which MCP is missing
+**If either is unavailable:**
+- Stop immediately — tell the user which MCP is missing
 - Do not proceed with any semantic operation
 - Do not fall back to bash, grep, or sed as substitutes
 - Wait for the user to reconnect via `/mcp`
 
-**If both are available:** confirm and continue.
+IntelliJ can also drop mid-task. If a semantic operation fails because an MCP
+is unavailable at any point, stop and tell the user rather than silently falling back.
 
-IntelliJ can also drop mid-task. If at any point during the work a semantic
-operation fails because an MCP is unavailable, stop again and tell the user
-rather than silently falling back.
+### Step 12 — Offer brainstorming
+
+> "Start a brainstorm? (y/n)"
+
+If yes: invoke `superpowers:brainstorming`. Specs write to `$WORKSPACE/specs/<branch-name>/`.
+Specs always route to `project` (`$PROJECT/docs/specs/`) at close — the three-layer
+cascade covers blog/adr/snapshots/plans/design only.
 
 ---
 
-## Done — Report and Hand Off
+## Resume Path (Detection state 2)
 
-Output a brief summary:
+Surface `.meta`:
+```
+⚡ Resuming: <branch-name>  Issue: #<N>  Started: <date>
+   Flyway V: <N | none | unknown>
+   Project: <branch>  Workspace: <branch>
+```
+
+Run Steps 0, 2, 3, 11 only. Skip all branch creation steps.
+
+---
+
+## Done — Report
 
 ```
 work-start complete.
+Branch: <branch-name>  Issue: #<N>
 Platform doc: [read / not found]
 Coherence Protocol: [any concerns raised, or "clear"]
 Protocols checked: [list any relevant ones read]
-Issue: #N — [title]
 IntelliJ: ✅ both connected / ⚠️ [missing — stopped]
 
-Proceeding to brainstorming.
+Proceeding to brainstorming.  (or: Ready for work.)
 ```
-
-Then hand off to `superpowers:brainstorming` on the described work.

--- a/work-start/SKILL.md
+++ b/work-start/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: work-start
 description: >
-  MUST be invoked at the start of every piece of work — user says "work-start",
-  or it appears as the first instruction in a work-item prompt. Detects current
-  branch state, creates a branch if needed, scaffolds .meta + JOURNAL.md, and
-  runs pre-checks before any design or implementation begins. Replaces the
-  former two-step "work-start + /epic begin" workflow — branch creation is now
-  integrated. These checks are NOT optional and must NOT be skipped even for
-  small changes.
+  Use when a task or session is beginning — the opening directive in any
+  work-item prompt, or when the user says they are beginning work. Handles
+  both new and existing branches. NOT optional, must NOT be skipped.
 ---
 
 # work-start

--- a/work-start/commands/work-start.md
+++ b/work-start/commands/work-start.md
@@ -1,0 +1,5 @@
+---
+description: "MUST be invoked at the start of every piece of work — user says "work-start", or it appears as th..."
+---
+
+Invoke the `work-start` skill.

--- a/write-content/SKILL.md
+++ b/write-content/SKILL.md
@@ -118,7 +118,7 @@ Before presenting:
 
 **Consumed by:**
 - `write-blog` — invokes write-content for content type and writing, adds blog-specific publishing rules
-- Future: `write-paper`, `write-post` — same pattern
+- Future: write-paper, write-post — same pattern (not yet implemented)
 
 **Loads:**
 - `write-content/defaults/structure-principles.md` — always


### PR DESCRIPTION
## Summary

Implements the unified work lifecycle design (cc-praxis#94). Four new commands replace the fragmented `work-start` + `epic begin/close` workflow:

- **`work-start`** — unified entry point; 6-state detection, atomic branch creation (`issue-NNN-<slug>`), `.meta` + `JOURNAL.md` scaffold, platform coherence + protocol + IntelliJ pre-checks, optional brainstorming
- **`work-end`** — artifact routing (3-layer cascade), journal merge into DESIGN.md, issue close, `EPIC-CLOSED.md` marker, return to main
- **`work-pause`** — stash with recorded references, atomic `.paused` marker on workspace main (push must succeed before switching repos), both repos to main
- **`work-resume`** — reads `.paused`, switches repos back, removes pause marker, restores stashes by recorded position (not bare stash pop), pre-checks

**Supporting changes:**
- `epic/SKILL.md`: deprecation header pointing to new commands
- `java-update-design/SKILL.md`: fix workspace mode detection — `.meta` + `JOURNAL.md` + not-on-main replaces broken `epic-*` prefix check (silently bypassed journal on `issue-NNN-*` branches)
- `CLAUDE.md` + `DESIGN.md`: skill index and architectural decision record
- `docs/skills-catalog.md`, `update-primary-doc/SKILL.md`: update cross-references from epic to work-end

Also includes: fix(#66) — workspace detection via wksp symlink fallback (committed on this branch from the prior session).

## Key design decisions

- Detection state 3 (orphaned `.meta` on main) must be checked BEFORE state 4 (misaligned branches) — both satisfy "misaligned" and state 4 would try to switch to a deleted branch
- `design-repo:` stored in `.meta` — not re-derived from routing config which may change between sessions
- Journal merge happens during 8a main-visit when `design → workspace` — epic branch commits are discarded at close
- Atomic pause: push must succeed before writing `.paused` to main
- Stash references recorded (`stash@{N}`) — bare `stash pop` pops wrong stash if stack shifts

## Test plan

- [ ] `work-start` on main with no `.meta` → creates `issue-NNN-<slug>` branch in both repos, writes `.meta` with design-repo + section hashes
- [ ] `work-start` on existing branch (detection state 2) → resumes, runs pre-checks only
- [ ] `work-start` with orphaned `.meta` on main (state 3) → hard stop before Branch Switch Helper
- [ ] `work-pause` on clean repos → no stash prompt, `stash@{0}` not recorded
- [ ] `work-pause` on dirty repos → stash recorded only if `git stash` reports "Saved working directory"
- [ ] `work-resume` after pause → restores by `stash@{N}`, not bare pop
- [ ] `work-end` with `design-repo: project` → journal merge on project epic branch (in PR)
- [ ] `work-end` with `design-repo: workspace` → journal merge during 8a main-visit, not on epic branch
- [ ] `java-update-design` on `issue-NNN-*` branch with `.meta` present → workspace mode (journal entry), not direct DESIGN.md write

Closes #94